### PR TITLE
Repository URL fix

### DIFF
--- a/DropDownPackage/DropDownPackage.csproj
+++ b/DropDownPackage/DropDownPackage.csproj
@@ -16,7 +16,7 @@
 		<Authors>Antonio Glešić</Authors>
 		<Company></Company>
 		<Description>My blazor dropdown component</Description>
-		<RepositoryUrl>https://github.com/antglesic/GrabaDropDowns</RepositoryUrl>
+		<RepositoryUrl>https://github.com/antglesic/DropDownPackage</RepositoryUrl>
 		<RepositoryType>git</RepositoryType>
 		<PackageTags>Blazor, dropdown, component</PackageTags>
 		<OutputType>Library</OutputType>


### PR DESCRIPTION
#### PR Classification
Update the repository URL in the project file.

#### PR Summary
The pull request updates the repository URL in the `DropDownPackage.csproj` file to reflect the new project location. 
- `DropDownPackage.csproj`: Changed `RepositoryUrl` from `https://github.com/antglesic/GrabaDropDowns` to `https://github.com/antglesic/DropDownPackage`.
